### PR TITLE
Plugin repository needed to assemble distribution binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,16 @@
       </plugins>
    </build>
 
+   <pluginRepositories>
+      <pluginRepository>
+         <id>external dependencies</id>
+<!-- repository https://copernicus.serco.eu/repository/nexus/content/repositories/releases
+     used to proxy gael's resources requires credentials
+     Using alternative source repository. -->
+         <url>https://repository.gael-systems.com/repository/public</url>
+      </pluginRepository>
+   </pluginRepositories>
+
    <repositories>
       <repository>
          <id>external dependencies</id>


### PR DESCRIPTION
When fr.gael.plexus:plexus-archiver-shar is not locally cached, the build fails. This patch let maven to use external dependencies repository for the maven plugins too.